### PR TITLE
change scaling factor reset to default setting in gnome 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -198,8 +198,8 @@ main() {
         gsettings get org.gnome.settings-daemon.plugins.xsettings overrides | grep -q "'Gdk/WindowScalingFactor': <2>"
         if [ $? -eq 0 ]; then
             echo "Removing experimental GDK WindowScalingFactor 2..."
-            gsettings set org.gnome.settings-daemon.plugins.xsettings overrides "[{'Gdk/WindowScalingFactor', <1>}]"
-            gsettings set org.gnome.desktop.interface scaling-factor 1
+            gsettings set org.gnome.settings-daemon.plugins.xsettings overrides "@a{sv} {}"
+            gsettings set org.gnome.desktop.interface scaling-factor 0
             echo "Applying 100%: "$((${res10_width%.*}/2))"x"$((${res10_height%.*}/2))
             echo "Removed experimental GDK scaling, no xrandr scaling needed."
             echo "Please logoff and back on."


### PR DESCRIPTION
after usiing betterScale for a few minutes, i reset the scale to 100% reset to default. But when i try to use gnome fractional scaling to 125%, the window is shrinking instead of larging. After some debugging, i found that default value for gsettings set org.gnome.settings-daemon.plugins.xsettings overrides is {} and gsettings set org.gnome.desktop.interface scaling-factor is 0.